### PR TITLE
Remove zero-width non-breaking spaces.

### DIFF
--- a/GravityTurn/VesselState.cs
+++ b/GravityTurn/VesselState.cs
@@ -275,7 +275,7 @@ namespace GravityTurn
         {
             if (isLoadedFAR == true)
             {
-                AssemblyLoader.LoadedAssembly﻿ FAR = AssemblyLoader.loadedAssemblies.SingleOrDefault(a => a.dllName == "FerramAerospaceResearch");
+                AssemblyLoader.LoadedAssembly FAR = AssemblyLoader.loadedAssemblies.SingleOrDefault(a => a.dllName == "FerramAerospaceResearch");
                 //try
                 //{
                     return FAR.assembly.GetTypes().SingleOrDefault(t => t.Name == "FARAPI").GetMethod("CalculateVesselAeroForces", BindingFlags.Public | BindingFlags.Static);
@@ -296,7 +296,7 @@ namespace GravityTurn
         {
             if (isLoadedFAR == true)
             {
-                AssemblyLoader.LoadedAssembly﻿ FAR = AssemblyLoader.loadedAssemblies.SingleOrDefault(a => a.dllName == "FerramAerospaceResearch");
+                AssemblyLoader.LoadedAssembly FAR = AssemblyLoader.loadedAssemblies.SingleOrDefault(a => a.dllName == "FerramAerospaceResearch");
                 //try
                 //{
                     return FAR.assembly.GetTypes().SingleOrDefault(t => t.Name == "FARAPI").GetMethod("ActiveVesselDynPres", BindingFlags.Public | BindingFlags.Static);


### PR DESCRIPTION
This change looks like it doesn't do anything -- but it removes two
zero-width non-breaking spaces (ZWNBSP, i.e. 0xFEFF or the byte-order
mark).

Jetbrains Rider can't cope with these -- they become part of the symbol
which can then no longer be resolved. Purely a quality-of-life
improvement for building.