### PR TITLE
Guard reading rcsThrustAvailable with a null-check

### DIFF
--- a/GravityTurn/VesselState.cs
+++ b/GravityTurn/VesselState.cs
@@ -928,12 +928,22 @@ namespace GravityTurn
         }
 
         // Decide whether to control the RCS thrusters from the main throttle
+        //
+        // MacGyverNL: With the removal of the code setting / updating rcsThrustAvailable, a bug was introduced
+        //             because rcsThrustAvailable appears to always be null.
+        //             Without knowing more about the internals of this mod, I do not dare to touch it
+        //             beyond putting a defensive if-statement around the update of thrustVectorMaxThrottle.
+        //             The boolean that this method sets does not appear to be ever used inside the mod,
+        //             but it's declared public so I didn't dare to comment it out entirely.
         void ToggleRCSThrust(Vessel vessel)
         {
             if (thrustVectorMaxThrottle.magnitude == 0 && vessel.ActionGroups[KSPActionGroup.RCS])
             {
                 rcsThrust = true;
-                thrustVectorMaxThrottle += (Vector3d)(vessel.transform.up) * rcsThrustAvailable.down;
+                if (rcsThrustAvailable != null)
+                {
+                    thrustVectorMaxThrottle += (Vector3d)(vessel.transform.up) * rcsThrustAvailable.down;
+                }
             }
             else
             {


### PR DESCRIPTION
With the removal of the code setting / updating `rcsThrustAvailable`, a
bug was introduced because `rcsThrustAvailable` appears to always be `null`,
but a member is accessed in `ToggleRCSThrust`

This appears to have first been noticed back in 2017 by [Gordon Dry](https://forum.kerbalspaceprogram.com/index.php?/topic/148448-14177-gravityturn-continued-automated-efficient-launches/page/14/&tab=comments#comment-3063561) and [GreyRaven75](https://forum.kerbalspaceprogram.com/index.php?/topic/148448-14177-gravityturn-continued-automated-efficient-launches/page/15/&tab=comments#comment-3092858) -- but not fixed.

It manifests for me when, on my install, I:
1. perform a GravityTurn launch, not touching any throttle myself at all
2. reach a trajectory while in-atmo with an Ap. of 100km
3. wait until the vessel is between 70km and 100km (out of atmo)
4. stage into a stage with only RCS, no normal engines
5. enable RCS
6. watch the game slow down to 1FPS and spam NullReferenceExceptions into the log

Without knowing more about the internals of this mod, I do not dare to
touch it beyond putting a defensive if-statement around the update of
thrustVectorMaxThrottle.

The boolean that this method sets does not appear to be ever used inside
the mod, but it's declared public so I didn't dare to comment it out
entirely.