### PR TITLE
Fix for #14

### DIFF
--- a/GravityTurn/GravityTurner.cs
+++ b/GravityTurn/GravityTurner.cs
@@ -706,7 +706,7 @@ namespace GravityTurn
 
         public string GetFlightMapFilename()
         {
-            return LaunchDB.GetBaseFilePath(this.GetType(), string.Format("gt_vessel_{0}_{1}.png", LaunchName, LaunchBody.name).Replace('/', '_').Replace('\\', '_'));
+            return LaunchDB.GetBaseFilePath(this.GetType(), string.Format("gt_vessel_{0}_{1}.png", LaunchName, LaunchBody.name));
         }
 
         public void Kill()

--- a/GravityTurn/GravityTurner.cs
+++ b/GravityTurn/GravityTurner.cs
@@ -706,7 +706,7 @@ namespace GravityTurn
 
         public string GetFlightMapFilename()
         {
-            return LaunchDB.GetBaseFilePath(this.GetType(), string.Format("gt_vessel_{0}_{1}.png", LaunchName, LaunchBody.name).Replace('/', '_').Replace('\', '_'));
+            return LaunchDB.GetBaseFilePath(this.GetType(), string.Format("gt_vessel_{0}_{1}.png", LaunchName, LaunchBody.name).Replace('/', '_').Replace('\\', '_'));
         }
 
         public void Kill()

--- a/GravityTurn/GravityTurner.cs
+++ b/GravityTurn/GravityTurner.cs
@@ -706,7 +706,7 @@ namespace GravityTurn
 
         public string GetFlightMapFilename()
         {
-            return LaunchDB.GetBaseFilePath(this.GetType(), string.Format("gt_vessel_{0}_{1}.png", LaunchName, LaunchBody.name));
+            return LaunchDB.GetBaseFilePath(this.GetType(), string.Format("gt_vessel_{0}_{1}.png", LaunchName, LaunchBody.name).Replace('/', '_').Replace('\', '_'));
         }
 
         public void Kill()

--- a/GravityTurn/LaunchDB.cs
+++ b/GravityTurn/LaunchDB.cs
@@ -346,9 +346,7 @@ namespace GravityTurn
 
         public static string GetBaseFilePath(Type t, string sub)
         {
-            var str = System.IO.Directory.GetCurrentDirectory() + @"/GameData/GravityTurn/PluginData/" + sub;
-            //return System.IO.Directory.GetCurrentDirectory() + @"/GameData/GravityTurn/PluginData/" + sub;
-            return KSPUtil.SanitizeFilename(str);
+            return System.IO.Directory.GetCurrentDirectory() + @"/GameData/GravityTurn/PluginData/" + KSPUtil.SanitizeFilename(sub);
         }
     }
 }

--- a/GravityTurn/LaunchDB.cs
+++ b/GravityTurn/LaunchDB.cs
@@ -346,7 +346,7 @@ namespace GravityTurn
 
         public static string GetBaseFilePath(Type t, string sub)
         {
-            return System.IO.Directory.GetCurrentDirectory() + @"/GameData/GravityTurn/PluginData/" + sub;
+            return System.IO.Directory.GetCurrentDirectory() + @"/GameData/GravityTurn/PluginData/" + sub.Replace('/', '_').Replace('\\', '_');
         }
     }
 }


### PR DESCRIPTION
As mentioned in the description of #14, `KSPUtil.SanitizeFilename()` should be called on the filename, not the full path. This merge request fixes that.